### PR TITLE
Add core DSC data-tooling gaps: yq, yamllint, git-lfs, xan, pandoc, shellcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,14 @@ Unix tools:
 * [Watchman] for watching for filesystem events
 * [Zsh] as your shell
 * [rlwrap] readline wrapper
+* [pandoc] markup converter (also used under the hood by Quarto)
 * [tree]  lists contents of directory in a tree like structure
 * [jq] JSON parser 
+* [yq] YAML/XML processor, same idea as jq -- used on `project-registry.yaml`, Carpentries lesson `config.yaml`, and GitHub workflow files
 * [wget] network downloader 
 * [rclone] cloud storage data synch 
+* [git-lfs] Git support for large data files
+* [xan] fast CSV toolkit for data work
 * [docker] container runtime (Docker Desktop, includes CLI + GUI)
 
 [Universal Ctags]: https://ctags.io/
@@ -107,10 +111,14 @@ Unix tools:
 [Tmux]: http://tmux.github.io/
 [Watchman]: https://facebook.github.io/watchman/
 [rlwrap]: https://linux.die.net/man/1/rlwrap
+[pandoc]: https://pandoc.org
 [tree]: https://linux.die.net/man/1/tree
 [jq]: https://stedolan.github.io/jq/
+[yq]: https://github.com/mikefarah/yq
 [wget]: https://www.geeksforgeeks.org/wget-command-in-linux-unix/
 [rclone]: https://rclone.org
+[git-lfs]: https://git-lfs.com/
+[xan]: https://github.com/medialab/xan
 [docker]: https://www.docker.com/products/docker-desktop/
 
 * [GitHub CLI] for interacting with the GitHub API
@@ -137,6 +145,13 @@ Languages and editors:
 [Node.js]: https://nodejs.org/
 [Quarto]: https://quarto.org/
 
+Linting / repo maintenance:
+
+* [ShellCheck] for shell script linting (used on `mac` itself, see Contributing below)
+* [yamllint] for YAML linting
+
+[yamllint]: https://yamllint.readthedocs.io/
+
 It should take less than 15 minutes to install (depends on your machine).
 
 See the [wiki](https://github.com/UCLA-DataSquad/laptop/wiki)
@@ -147,10 +162,10 @@ Contributing
 
 1. Edit the `mac` file.
 2. Document in the `README.md` file.
-3. Follow shell style guidelines by using [ShellCheck] and [Syntastic].
+3. Follow shell style guidelines by using [ShellCheck] and [Syntastic]. `shellcheck` is installed by `mac` itself (see above), so if you've already run the script once you have it:
 
 ```sh
-brew install shellcheck
+shellcheck -s sh mac
 ```
 
 [ShellCheck]: http://www.shellcheck.net/about.html

--- a/mac
+++ b/mac
@@ -103,11 +103,14 @@ brew "xz"
 brew "libxt" 
 brew "cairo"
 brew "rlwrap"
-#brew "pandoc"
+brew "pandoc"
 brew "tree"
 brew "jq"
+brew "yq"
 brew "wget"
 brew "rclone"
+brew "git-lfs"
+brew "xan"
 
 # GitHub
 brew "gh"
@@ -118,6 +121,10 @@ brew "imagemagick"
 # Programming language prerequisites and package managers
 brew "libyaml" # should come after openssl
 brew "coreutils"
+
+# Linting / repo maintenance
+brew "shellcheck"
+brew "yamllint"
 
 #Programming languages
 brew "r"
@@ -145,6 +152,9 @@ brew cleanup
 fancy_echo "Setting up Miniforge conda ..."
 conda init "$(basename "${SHELL}")"
 conda update -y conda
+
+fancy_echo "Setting up git-lfs ..."
+git lfs install
 
 # uncomment if you want to create and run your own local additions to this script
 #if [ -f ".laptop.local" ]; then


### PR DESCRIPTION
Follow-up to #11, which you merged before this last commit landed on the branch.

Cross-checked your actual Homebrew leaves (`brew leaves`) against what the script installs, per your request to evaluate the tools in use, not just the version drift. Five gaps you confirmed as worth adding:

- **`pandoc`**: was commented out entirely in the old script; you have it as a standalone leaf, not just riding in as a Quarto dependency
- **`yq`**: YAML sibling to `jq` (already in the script) — used on `project-registry.yaml`, Carpentries lesson `config.yaml`, GitHub workflow files
- **`yamllint`**: validates the same YAML files
- **`git-lfs`**: large file support in git, relevant for DSC's datasets — also runs `git lfs install` after `brew bundle` so the hooks are actually registered, not just the binary present
- **`xan`**: fast CSV toolkit, core to DSC's data work
- **`shellcheck`**: I installed this myself to validate `mac` during the #11 review — keeping it in the script so future maintainers have it without a manual step; updated the Contributing section's instructions to match

Left out as personal-preference rather than DSC-standard (your call, not mine): `podman` (already decided Docker Desktop for the shared script), `ollama`, and general CLI tools (`fzf`, `neovim`, `go`, etc). Also left out `hugo`/`rbenv` (for the Jekyll/Hugo sites) and MacTeX/TinyTeX (for Quarto PDF output) — flagged as open questions rather than added, since I wasn't sure those are common enough pain points to bake into a shared onboarding script yet.

## Test plan
- [x] `shellcheck -s sh mac` — same pre-existing warning set, nothing new
- [x] `brew bundle check` — all formula names resolve
- [ ] Real CI run on this commit (in progress as of PR open)