### PR TITLE
Maintenance: drop unused tap, fix Homebrew install URL, README drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,76 @@
 [![Smoke Test CI](https://github.com/UCLA-DataSquad/laptop/actions/workflows/smoke.yml/badge.svg)](https://github.com/UCLA-DataSquad/laptop/actions/workflows/smoke.yml)
 
-DSC - DataSquad Laptop Setup (for MacBook)
-======
+# DataSquad Laptop Setup
 
-**Laptop** is a script to set up a macOS laptop for data science tools for DSC staff & Data Squad.
+A one-command macOS setup script that turns a fresh MacBook into a working
+data science consulting environment for the UCLA Library Data Science Center
+(DSC) and its student consultant program, DataSquad.
 
-* It can be run multiple times on the same machine safely.
-* It installs, upgrades, or skips packages
-based on what is already installed on the machine.
+## Contents
 
+- [Why this exists](#why-this-exists)
+- [How it works](#how-it-works)
+- [Requirements](#requirements)
+- [Install](#install)
+- [Debugging](#debugging)
+- [What it sets up](#what-it-sets-up)
+- [Known Issues](#known-issues)
+- [Contributing](#contributing)
+- [License](#license)
 
-Requirements
-------------
+## Why this exists
 
-This script supports:
+Every academic term, DSC onboards new DataSquad student consultants and
+occasionally new staff, each of whom needs the same working set of tools
+before they can help a researcher clean a dataset, build a map, or debug an R
+script. Recreating that setup by hand from memory or an out-of-date wiki page
+is slow, inconsistent between machines, and silently drifts from what the
+job actually requires.
 
-* macOS Big Sur (11.2) - Apple Silicon 
+This script exists to make that setup **reproducible and versioned**: the
+toolchain is defined once, in code, and installing or catching up a machine
+is a single command instead of a checklist. It started as a fork of
+[thoughtbot/laptop](https://github.com/thoughtbot/laptop), a well-tested
+general web-dev setup script, and has been adapted over time for a data
+science *consulting* audience rather than a Rails shop.
 
-To make backward compatable we need to add some logic to test for architecture. 
+As of July 2026, the tool list is no longer just inherited thoughtbot
+defaults — it's reviewed against **what DSC consultations actually ask for**.
+Real consultation-request data showed GIS work as the single largest
+consulting topic and Tableau as a frequently named tool, for example, neither
+of which had any supporting software installed until that review. See
+[Known Issues](#known-issues) for the full methodology and what's still
+pending a decision.
 
-NOTE: Homebrew installs to `/opt/homebrew` on Apple Silicon rather than `/usr/local` so `HOMEBREW_PREFIX` probably needs to be dependant on the architecture. see: <https://github.com/thoughtbot/laptop/issues/589>
+## How it works
 
-* macOS Mavericks (10.9)
-* macOS Yosemite (10.10)
-* macOS El Capitan (10.11)
-* macOS Sierra (10.12)
-* macOS High Sierra (10.13)
-* macOS Mojave (10.14)
-* macOS Catalina (10.15)
+- **Idempotent**: safe to run repeatedly. It installs, upgrades, or skips
+  each package based on what's already on the machine, so re-running it after
+  a few months to catch a laptop up to the current tool list is normal usage,
+  not a special "repair" mode.
+- **One source of truth**: the entire package list lives in a single
+  `brew bundle` block inside `mac` — no separate Brewfile to keep in sync,
+  no tribal knowledge about what else to `brew install` by hand afterward.
+- **Tested on every change**: a GitHub Actions workflow
+  (`.github/workflows/smoke.yml`) runs the full script on a real,
+  GitHub-hosted macOS runner for every push and PR, so a broken tap or a
+  typo'd formula name fails CI instead of failing on a new hire's first day.
+- **Evidence over assumption**: package additions and removals are expected
+  to point at a reason — a documented DSC need, a verified dependency
+  relationship (`brew deps`/`brew uses`), or real consultation-request
+  volume — not just "this seemed useful." See [Known Issues](#known-issues)
+  for the review trail.
 
-Older versions may work but aren't tested.
-Bug reports for older versions are welcome.
+## Requirements
 
-To Install
--------
+Apple Silicon Macs running a current macOS release. The script has not been
+tested on Intel Macs or on macOS versions predating Apple Silicon, and no
+compatibility work is planned for those (DSC issues Apple Silicon MacBooks
+exclusively). Homebrew installs to `/opt/homebrew` on Apple Silicon rather
+than `/usr/local`; the script accounts for this directly rather than trying
+to detect architecture.
+
+## Install
 
 Download the script:
 
@@ -53,7 +90,9 @@ Execute the downloaded script:
 sh mac 2>&1 | tee ~/laptop.log
 ```
 
-You'll need to use your laptop password. If it's the first time running this script, it will trigger an installation of Xcode and you will need to hit return. 
+You'll need to use your laptop password. If it's the first time running this
+script, it will trigger an installation of Xcode and you will need to hit
+return.
 
 Optionally, review the log:
 
@@ -65,17 +104,19 @@ Optionally, [install thoughtbot/dotfiles][dotfiles].
 
 [dotfiles]: https://github.com/thoughtbot/dotfiles#install
 
-Debugging
----------
+It should take less than 15 minutes to install on a fresh machine (depends on
+your machine and network). Re-running it later to pick up new tools is much
+faster, since already-installed packages are skipped.
 
-Your last Laptop run will be saved to `~/laptop.log`.
+## Debugging
+
+Your last run will be saved to `~/laptop.log`.
 Read through it to see if you can debug the issue yourself.
 If not, copy the lines where the script failed into a
 [new GitHub Issue](https://github.com/UCLA-DataSquad/laptop/issues/new) for us.
 Or, attach the whole log file as an attachment.
 
-What it sets up
----------------
+## What it sets up
 
 macOS tools:
 
@@ -116,6 +157,7 @@ Unix tools:
 [ripgrep]: https://github.com/BurntSushi/ripgrep
 [Tmux]: http://tmux.github.io/
 [Watchman]: https://facebook.github.io/watchman/
+[Zsh]: https://www.zsh.org/
 [coreutils]: https://www.gnu.org/software/coreutils/
 [rlwrap]: https://linux.die.net/man/1/rlwrap
 [pandoc]: https://pandoc.org
@@ -137,6 +179,8 @@ Unix tools:
 Image tools:
 
 * [ImageMagick] for cropping and resizing images
+
+[ImageMagick]: https://imagemagick.org/
 
 Geospatial:
 
@@ -186,13 +230,10 @@ Linting / repo maintenance:
 
 [yamllint]: https://yamllint.readthedocs.io/
 
-It should take less than 15 minutes to install (depends on your machine).
-
 See the [wiki](https://github.com/UCLA-DataSquad/laptop/wiki)
 for more customization examples.
 
-Known Issues
-------------
+## Known Issues
 
 This script is a fork of [thoughtbot/laptop](https://github.com/thoughtbot/laptop)
 (a general web-dev setup script), adapted over time for data science
@@ -220,11 +261,11 @@ gallery by default — needs a documented opt-in rather than a silent install
 given patron-data handling) and whether to pilot `jamovi` as a gentler
 stats-GUI on-ramp for students.
 
-Contributing
-------------
+## Contributing
 
 1. Edit the `mac` file.
-2. Document in the `README.md` file.
+2. Document in the `README.md` file — say *why*, not just *what*, if you're
+   adding or removing a package (see [Why this exists](#why-this-exists)).
 3. Follow shell style guidelines by using [ShellCheck] and [Syntastic]. `shellcheck` is installed by `mac` itself (see above), so if you've already run the script once you have it:
 
 ```sh
@@ -245,12 +286,11 @@ you agree to abide by the thoughtbot [code of conduct].
 
 [code of conduct]: https://thoughtbot.com/open-source-code-of-conduct
 
-License
--------
+## License
 
-Laptop is © 2011-2020 thoughtbot, inc.
-It is free software,
-and may be redistributed under the terms specified in the [LICENSE] file.
+This repository is a fork of [thoughtbot/laptop](https://github.com/thoughtbot/laptop)
+and retains thoughtbot's original MIT license, per the terms of that license
+(copyright 2011-2020 thoughtbot, inc.) — see the [LICENSE] file. UCLA DSC's
+changes on top of the original are contributed under the same license.
 
 [LICENSE]: LICENSE
-

--- a/README.md
+++ b/README.md
@@ -85,13 +85,16 @@ macOS tools:
 
 Unix tools:
 
-* [Universal Ctags] for indexing files for vim tab completion
+* [Universal Ctags] for indexing files for vim tab completion (built from HEAD)
 * [Git] for version control
 * [OpenSSL] for Transport Layer Security (TLS)
+* [RCM] dotfiles management (thoughtbot template default; under review — see Known Issues)
+* [reattach-to-user-namespace] tmux/pasteboard integration shim (thoughtbot template default; under review — see Known Issues)
 * [The Silver Searcher] for finding things in files
 * [Tmux] for saving project state and switching between projects
 * [Watchman] for watching for filesystem events
 * [Zsh] as your shell
+* gcc, xz, libxt, cairo, libyaml, coreutils — build/library dependencies pulled in for R and other formulae (thoughtbot template defaults; under review — see Known Issues)
 * [rlwrap] readline wrapper
 * [pandoc] markup converter (also used under the hood by Quarto)
 * [tree]  lists contents of directory in a tree like structure
@@ -107,6 +110,7 @@ Unix tools:
 [Git]: https://git-scm.com/
 [OpenSSL]: https://www.openssl.org/
 [RCM]: https://github.com/thoughtbot/rcm
+[reattach-to-user-namespace]: https://github.com/ChrisJohnsen/tmux-MacOSX-pasteboard
 [The Silver Searcher]: https://github.com/ggreer/the_silver_searcher
 [Tmux]: http://tmux.github.io/
 [Watchman]: https://facebook.github.io/watchman/
@@ -128,6 +132,14 @@ Unix tools:
 Image tools:
 
 * [ImageMagick] for cropping and resizing images
+
+Apps:
+
+* [OpenRefine] for cleaning and transforming messy data
+* [iTerm2] terminal emulator
+
+[OpenRefine]: https://openrefine.org/
+[iTerm2]: https://iterm2.com/
 
 Languages and editors:
 
@@ -156,6 +168,19 @@ It should take less than 15 minutes to install (depends on your machine).
 
 See the [wiki](https://github.com/UCLA-DataSquad/laptop/wiki)
 for more customization examples.
+
+Known Issues
+------------
+
+This script is a fork of [thoughtbot/laptop](https://github.com/thoughtbot/laptop)
+(a general web-dev setup script), adapted over time for data science
+consulting work.
+
+Several packages marked "under review" above (`rcm`, `reattach-to-user-namespace`,
+`gcc`/`xz`/`libxt`/`cairo`/`libyaml`/`coreutils`, `universal-ctags` HEAD build,
+`vim`, `watchman`, `the_silver_searcher`) may be unused thoughtbot-template
+leftovers rather than confirmed DataSquad needs — pending an external tooling
+review before removal.
 
 Contributing
 ------------

--- a/README.md
+++ b/README.md
@@ -85,25 +85,27 @@ macOS tools:
 
 Unix tools:
 
-* [Universal Ctags] for indexing files for vim tab completion (built from HEAD)
+* [Universal Ctags] for indexing files for vim tab completion (built from HEAD; under review — see Known Issues)
 * [Git] for version control
 * [OpenSSL] for Transport Layer Security (TLS)
 * [RCM] dotfiles management (thoughtbot template default; under review — see Known Issues)
 * [reattach-to-user-namespace] tmux/pasteboard integration shim (thoughtbot template default; under review — see Known Issues)
-* [The Silver Searcher] for finding things in files
+* [ripgrep] fast recursive code/text search (replaces the older `the_silver_searcher`)
 * [Tmux] for saving project state and switching between projects
-* [Watchman] for watching for filesystem events
+* [Watchman] for watching for filesystem events (under review — see Known Issues)
 * [Zsh] as your shell
-* gcc, xz, libxt, cairo, libyaml, coreutils — build/library dependencies pulled in for R and other formulae (thoughtbot template defaults; under review — see Known Issues)
+* [coreutils] GNU command-line utilities for BSD/macOS parity (under review — see Known Issues)
 * [rlwrap] readline wrapper
 * [pandoc] markup converter (also used under the hood by Quarto)
 * [tree]  lists contents of directory in a tree like structure
+* [tealdeer] fast `tldr` — short, example-driven command help for the CLI tools on this list
 * [jq] JSON parser 
 * [yq] YAML/XML processor, same idea as jq -- used on `project-registry.yaml`, Carpentries lesson `config.yaml`, and GitHub workflow files
 * [wget] network downloader 
 * [rclone] cloud storage data synch 
 * [git-lfs] Git support for large data files
 * [xan] fast CSV toolkit for data work
+* [duckdb] local SQL engine for querying/joining CSV, JSON, and Parquet files directly from the CLI, no server required
 * [docker] container runtime (Docker Desktop, includes CLI + GUI)
 
 [Universal Ctags]: https://ctags.io/
@@ -111,18 +113,21 @@ Unix tools:
 [OpenSSL]: https://www.openssl.org/
 [RCM]: https://github.com/thoughtbot/rcm
 [reattach-to-user-namespace]: https://github.com/ChrisJohnsen/tmux-MacOSX-pasteboard
-[The Silver Searcher]: https://github.com/ggreer/the_silver_searcher
+[ripgrep]: https://github.com/BurntSushi/ripgrep
 [Tmux]: http://tmux.github.io/
 [Watchman]: https://facebook.github.io/watchman/
+[coreutils]: https://www.gnu.org/software/coreutils/
 [rlwrap]: https://linux.die.net/man/1/rlwrap
 [pandoc]: https://pandoc.org
 [tree]: https://linux.die.net/man/1/tree
+[tealdeer]: https://github.com/tealdeer-rs/tealdeer
 [jq]: https://stedolan.github.io/jq/
 [yq]: https://github.com/mikefarah/yq
 [wget]: https://www.geeksforgeeks.org/wget-command-in-linux-unix/
 [rclone]: https://rclone.org
 [git-lfs]: https://git-lfs.com/
 [xan]: https://github.com/medialab/xan
+[duckdb]: https://duckdb.org
 [docker]: https://www.docker.com/products/docker-desktop/
 
 * [GitHub CLI] for interacting with the GitHub API
@@ -133,26 +138,43 @@ Image tools:
 
 * [ImageMagick] for cropping and resizing images
 
+Geospatial:
+
+* [QGIS] desktop GIS application — added because GIS is DSC's single largest
+  consultation topic and QGIS is explicitly named in patron requests
+* [GDAL] (`ogr2ogr`, `gdalinfo`) — CLI companion to QGIS for scripted format
+  conversion and reprojection
+
+[QGIS]: https://qgis.org/
+[GDAL]: https://gdal.org/
+
 Apps:
 
 * [OpenRefine] for cleaning and transforming messy data
 * [iTerm2] terminal emulator
+* [Positron] Posit's data science IDE (R/Python/Jupyter/Quarto in one editor);
+  installed alongside RStudio and VSCodium, not a replacement for either
 
 [OpenRefine]: https://openrefine.org/
 [iTerm2]: https://iterm2.com/
+[Positron]: https://positron.posit.co/
 
 Languages and editors:
 
 * [R] - Base R installed via Homebrew
 * [RStudio] - R IDE
 * [Miniforge] - conda-forge-based Python/conda distribution (follows [The Carpentries' 2025 setup recommendation](https://carpentries.org/blog/2025/03/lesson-setup-instructions-task-force-recommendations/) to move off Anaconda)
+* [pixi] - fast, project-based Python/conda package manager, taught in DataSquad workshops
+* [uv] - fast Python package/project manager (pip/venv/poetry replacement); installed so students and staff can drop into whatever setup a researcher's own project already expects (`pyproject.toml`, `uv.lock`, `requirements.txt`)
 * [VSCodium] - Python/shell/git editor (VS Code without Microsoft branding/telemetry), also per The Carpentries' 2025 recommendation
-* [Node.js] - JavaScript runtime + npm, for working in the Astro/Jekyll/Hugo site repos across DSC (Astro/Jekyll/Hugo themselves are scaffolded per-project via `npm`/`bundler`, not installed globally)
+* [Node.js] - pinned to the Active LTS line (`node@24`), for working in the Astro/Jekyll/Hugo site repos across DSC (Astro/Jekyll/Hugo themselves are scaffolded per-project via `npm`/`bundler`, not installed globally). Unversioned `node` tracks Homebrew's Current release, which changes out from under you and isn't recommended for production.
 * [Quarto] - scientific and technical publishing system used for DSC reports, slides, and stats
 
 [R]: https://www.r-project.org/
 [RStudio]: https://posit.co/products/open-source/rstudio/
 [Miniforge]: https://github.com/conda-forge/miniforge
+[pixi]: https://pixi.sh
+[uv]: https://docs.astral.sh/uv/
 [VSCodium]: https://vscodium.com/
 [Node.js]: https://nodejs.org/
 [Quarto]: https://quarto.org/
@@ -176,11 +198,27 @@ This script is a fork of [thoughtbot/laptop](https://github.com/thoughtbot/lapto
 (a general web-dev setup script), adapted over time for data science
 consulting work.
 
-Several packages marked "under review" above (`rcm`, `reattach-to-user-namespace`,
-`gcc`/`xz`/`libxt`/`cairo`/`libyaml`/`coreutils`, `universal-ctags` HEAD build,
-`vim`, `watchman`, `the_silver_searcher`) may be unused thoughtbot-template
-leftovers rather than confirmed DataSquad needs — pending an external tooling
-review before removal.
+A July 2026 evidence-based review (`validation-prompt-tooling-2026-07-26.md`,
+cross-checked against DSC's own consultation-request data and verified against
+primary sources — Homebrew, Node.js, Astro, and Positron docs — before
+adopting) confirmed and removed several genuinely redundant/unused packages
+(`gcc`, `xz`, `cairo`, `libxt`, `libyaml` — either transitive dependencies of
+`r` already, or depended on by nothing installed here) and added tools backed
+by real demand (`qgis`, `gdal`, `tableau`-adjacent GIS/viz gap; `duckdb`,
+`ripgrep`, `tealdeer`). One caveat from that review: an external
+keyword-frequency claim that R now outranks Python in consultation requests
+could not be reproduced from the underlying data (the merged consultation
+dataset blends real patron intake with Trello project-card text duplicated
+once per comment, which distorts any raw frequency count) — treat any future
+frequency claim from this dataset with that in mind.
+
+Still marked "under review," pending a decision (not yet confirmed either
+way): `rcm`, `reattach-to-user-namespace`, `universal-ctags` HEAD build,
+`vim`, `watchman`, `coreutils`. Also open: whether to add `tableau-public`
+(real demand, but Tableau Public auto-publishes saved workbooks to a public
+gallery by default — needs a documented opt-in rather than a silent install
+given patron-data handling) and whether to pilot `jamovi` as a gentler
+stats-GUI on-ramp for students.
 
 Contributing
 ------------

--- a/mac
+++ b/mac
@@ -88,24 +88,22 @@ brew "git"
 brew "openssl"
 brew "rcm"
 brew "reattach-to-user-namespace"
-brew "the_silver_searcher"
+brew "ripgrep" # replaces the_silver_searcher: actively maintained, faster, no functionality gap
 brew "tmux"
 brew "vim"
 brew "watchman"
 brew "zsh"
-brew "gcc" 
-brew "xz" 
-brew "libxt" 
-brew "cairo"
 brew "rlwrap"
 brew "pandoc"
 brew "tree"
+brew "tealdeer" # tldr command: short example-driven help for the CLI tools below
 brew "jq"
 brew "yq"
 brew "wget"
 brew "rclone"
 brew "git-lfs"
 brew "xan"
+brew "duckdb" # local SQL engine for querying/joining CSV, JSON, Parquet directly from the CLI
 
 # GitHub
 brew "gh"
@@ -113,8 +111,10 @@ brew "gh"
 # Image manipulation
 brew "imagemagick"
 
-# Programming language prerequisites and package managers
-brew "libyaml" # should come after openssl
+# Geospatial
+brew "gdal" # ogr2ogr/gdalinfo; CLI companion to QGIS below for scripted format conversion/reprojection
+
+# GNU utilities (BSD/macOS command parity)
 brew "coreutils"
 
 # Linting / repo maintenance
@@ -123,12 +123,16 @@ brew "yamllint"
 
 #Programming languages
 brew "r"
-brew "node" # provides node + npm; Astro/Jekyll/Hugo site tooling is scaffolded per-project via npm/bundler, not installed globally
+brew "node@24" # pinned to Active LTS; unversioned "node" tracks Homebrew's Current release (26 as of 2026-07), a moving target not recommended for production
+brew "pixi" # Python packaging, taught in DataSquad workshops
+brew "uv" # fast Python package/project manager, increasingly what researchers' own pyproject.toml/requirements.txt setups expect
 cask "miniforge"
 
 #apps
 cask "openrefine"
 cask "iterm2"
+cask "positron" # Posit's data science IDE (R/Python/Jupyter/Quarto); alongside RStudio/VSCodium, not a replacement
+cask "qgis" # GIS is DSC's single largest consultation topic; QGIS named explicitly in patron requests
 #cask "firefox"
 #cask "google-chrome"
 cask "docker-desktop"
@@ -136,6 +140,9 @@ cask "rstudio"
 cask "vscodium"
 cask "quarto"
 EOF
+
+fancy_echo "Linking node@24 (keg-only) ..."
+brew link --force node@24
 
 fancy_echo "Cleaning up old Homebrew formulae ..."
 brew cleanup

--- a/mac
+++ b/mac
@@ -69,12 +69,8 @@ esac
 if ! command -v brew >/dev/null; then
   fancy_echo "Installing Homebrew ..."
     /bin/bash -c \
-      "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+      "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
-    append_to_zshrc '# recommended by brew doctor'
-
-    # shellcheck disable=SC2016
-    #append_to_zshrc 'export PATH="/usr/local/bin:$PATH"' 1
     echo 'eval $(/opt/homebrew/bin/brew shellenv)' >> $HOME/.zprofile
     eval $(/opt/homebrew/bin/brew shellenv)
 
@@ -85,7 +81,6 @@ fancy_echo "Updating Homebrew formulae ..."
 brew update --force # https://github.com/Homebrew/brew/issues/1151
 brew bundle --file=- <<EOF
 tap "universal-ctags/universal-ctags"
-tap "buo/cask-upgrade"
 
 # Unix
 brew "universal-ctags", args: ["HEAD"]
@@ -141,10 +136,6 @@ cask "rstudio"
 cask "vscodium"
 cask "quarto"
 EOF
-
-#fancy_echo "Updating Brew Casks"
-
-#brew cu -a
 
 fancy_echo "Cleaning up old Homebrew formulae ..."
 brew cleanup


### PR DESCRIPTION
## Summary

**Commit 1 — mechanical fixes:**
- Homebrew bootstrap now uses `install/HEAD/install.sh` instead of a hardcoded `master` branch (Homebrew's currently recommended install command)
- Removed the unused `buo/cask-upgrade` tap — its only consumer (`brew cu -a`) has been commented out, so the tap was pure overhead on every run
- Removed an orphaned `append_to_zshrc` call that wrote a bare comment into `.zshrc` with no operative line following it

**Commit 2 — evidence-backed tool review:**
Ran an external validation pass on the full tool list, cross-checked against DSC's own consultation-request data and verified against primary sources (Homebrew, Node.js, Astro, Positron docs) before adopting anything — see `validation-prompt-tooling-2026-07-26.md` for the full methodology.

Added:
- `qgis`, `gdal` — GIS is DSC's largest consultation topic; QGIS named explicitly in patron requests; gdal is the CLI companion for scripted geospatial work
- `duckdb` — local SQL engine for querying/joining CSV/JSON/Parquet from the CLI
- `ripgrep` — replaces `the_silver_searcher` (actively maintained, faster, no functionality gap)
- `tealdeer` — `tldr` command for quick example-driven CLI help
- `positron` — alongside RStudio/VSCodium, not a replacement
- `pixi`, `uv` — Python packaging, now taught in DataSquad workshops and increasingly what researchers' own project configs already expect

Removed (verified via `brew deps r` / `brew uses` on a real machine, not guessed):
- `gcc`, `xz`, `cairo` — confirmed transitive dependencies of `r` already
- `libxt`, `libyaml` — confirmed unused by anything in this script

Changed:
- `node` → `node@24` — unversioned `node` currently installs 26 (Homebrew's Current release), not 24 (Active LTS). This repo's actual Astro consumers (`jt14den-astro`, `DataSquad-International.github.io`, `OSPO_WEBSITE`) require Node ≥22.12/22.0, which 26 happens to satisfy today, but it's a silently moving target across runs. `node@24` is keg-only, so added an explicit `brew link --force` step.

README updated to match. Still open (not resolved in this PR): `rcm`, `reattach-to-user-namespace`, ctags HEAD build, `vim`, `watchman`, `coreutils` remain "under review"; `tableau-public` and a `jamovi` pilot are flagged as follow-ups.

## Test plan
- [x] CI smoke test runs the full install on a fresh GitHub-hosted macOS runner (`.github/workflows/smoke.yml`)
- [x] Brewfile syntax validated locally with `brew bundle check`/`list` — no unknown formula/cask errors
- [x] `shellcheck -s sh mac` — no new warnings introduced beyond pre-existing ones