### PR TITLE
Add OSPO/RSE tooling for DataSquad students working as OSPO assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,40 @@ Linting / repo maintenance:
 
 [yamllint]: https://yamllint.readthedocs.io/
 
+OSPO / RSE tooling — DataSquad students increasingly work as OSPO assistants
+on the software-curation side of open source program office work (license
+compliance, citation/publishing, security posture), so these are installed
+alongside the general toolchain rather than assumed to be looked up later:
+
+* [pre-commit] manages multi-language git hooks (formatting, linting, secret
+  scanning) from a single `.pre-commit-config.yaml` per repo
+* [Copier] scaffolds a new repo from a template (tests, CI, docs, licensing,
+  community files) and can reapply template updates to existing repos later
+* [REUSE] SPDX-based license/copyright compliance; `reuse lint` catches
+  missing or inconsistent license headers
+* [OSV-Scanner] scans a repo's lockfiles/manifests against the OSV
+  vulnerability database
+* [zizmor] static analysis for GitHub Actions/Dependabot workflow configs;
+  catches insecure CI setups (overly broad permissions, unpinned actions)
+* [OpenSSF Scorecard] runnable locally, not just as a GitHub Action; checks a
+  repo's CI practices, code review requirements, pinned dependencies, and
+  other security posture signals
+
+More specialized OSPO/RSE tooling (repository templates built with the above,
+OpenSSF Scorecard as a CI check, `howfairis`/FAIR assessment, ScanCode
+Toolkit for auditing inherited codebases, CodeMeta, workflow engines like
+Snakemake/Nextflow, portfolio-health metrics via CHAOSS) is documented
+separately in DataSquad's own OSPO-assistant documentation rather than
+installed universally here — not everything on that list belongs on every
+laptop.
+
+[pre-commit]: https://pre-commit.com/
+[Copier]: https://copier.readthedocs.io/
+[REUSE]: https://reuse.software/
+[OSV-Scanner]: https://google.github.io/osv-scanner/
+[zizmor]: https://woodruffw.github.io/zizmor/
+[OpenSSF Scorecard]: https://github.com/ossf/scorecard
+
 See the [wiki](https://github.com/UCLA-DataSquad/laptop/wiki)
 for more customization examples.
 

--- a/mac
+++ b/mac
@@ -121,6 +121,14 @@ brew "coreutils"
 brew "shellcheck"
 brew "yamllint"
 
+# OSPO / RSE tooling (for DataSquad students working as OSPO assistants)
+brew "pre-commit" # manages multi-language git hooks (lint/format/secret-scan) from one config per repo
+brew "copier" # scaffolds new repos from a template (README/CI/tests/licensing) and reapplies template updates later
+brew "reuse" # REUSE tool: SPDX license/copyright compliance; 'reuse lint' catches missing license headers
+brew "osv-scanner" # scans a repo's lockfiles/manifests against the OSV vulnerability database
+brew "zizmor" # static analysis for GitHub Actions/Dependabot configs, catches insecure CI setups
+brew "scorecard" # OpenSSF Scorecard, runnable locally: checks CI, review practices, pinned deps, etc.
+
 #Programming languages
 brew "r"
 brew "node@24" # pinned to Active LTS; unversioned "node" tracks Homebrew's Current release (26 as of 2026-07), a moving target not recommended for production


### PR DESCRIPTION
## Summary

DataSquad students are increasingly hired as OSPO assistants — starting on the software-curation side of open source program office work (licensing, citation, security posture), with room to grow given CS backgrounds. This adds the tools from that review that are genuinely brew-installable CLI utilities, not GitHub-hosted features or frameworks:

- `pre-commit` — multi-language git hook manager, the clearest omission from the prior list
- `copier` — template scaffolding/reapplication for new repos
- `reuse` — SPDX license/copyright compliance (`reuse lint`)
- `osv-scanner` — lockfile/manifest vulnerability scanning
- `zizmor` — static analysis for GitHub Actions/Dependabot configs
- `scorecard` — OpenSSF Scorecard, runs locally not just as a CI action

Deliberately left out (not brew-installable, or better suited to DataSquad's own OSPO-assistant documentation rather than a universal laptop install): `howfairis` (pip/pipx only), ScanCode Toolkit (heavier staff-audit tool), CodeMeta/`codemetapy` (metadata generator, not brew-packaged), CFFInit (web tool), and the GitHub-hosted-feature layer (Dependabot, secret scanning, rulesets, Scorecard-as-Action) — that's repo configuration, not a laptop package.

Also fixed a real bug caught by `shellcheck` during this change: a comment containing backticks inside the unquoted `<<EOF` heredoc would have triggered actual shell command substitution when the script runs, not just been inert text.

## Test plan
- [x] Brewfile syntax validated with `brew bundle check` — no unknown formula/cask errors
- [x] `shellcheck -s sh mac` — no new warnings beyond pre-existing ones (caught and fixed a real backtick/heredoc issue in review)
- [ ] CI smoke test on GitHub-hosted macOS runner